### PR TITLE
Add unit tests

### DIFF
--- a/src/app/components/new-game-modal/new-game-modal.component.spec.ts
+++ b/src/app/components/new-game-modal/new-game-modal.component.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { NewGameModalComponent } from './new-game-modal.component';
+
+describe('NewGameModalComponent', () => {
+  let component: NewGameModalComponent;
+  let dialogRefSpy: jasmine.SpyObj<MatDialogRef<NewGameModalComponent>>;
+
+  beforeEach(async () => {
+    dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    await TestBed.configureTestingModule({
+      imports: [NewGameModalComponent],
+      providers: [{ provide: MatDialogRef, useValue: dialogRefSpy }]
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(NewGameModalComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should close dialog with data on startGame', () => {
+    component.playerName = 'Alice';
+    component.gameMode = 'remote';
+    component.startGame();
+    expect(dialogRefSpy.close).toHaveBeenCalledWith({ mode: 'remote', playerName: 'Alice' });
+  });
+
+  it('should not close dialog if playerName missing', () => {
+    component.playerName = '';
+    component.startGame();
+    expect(dialogRefSpy.close).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/services/dice.service.spec.ts
+++ b/src/app/services/dice.service.spec.ts
@@ -13,4 +13,28 @@ describe('DiceService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('rollDie returns value between 1 and 6', () => {
+    const value = service.rollDie();
+    expect(value).toBeGreaterThanOrEqual(1);
+    expect(value).toBeLessThanOrEqual(6);
+  });
+
+  it('rollDice returns requested number of dice', () => {
+    const result = service.rollDice(4);
+    expect(result.length).toBe(4);
+    result.forEach(v => {
+      expect(v).toBeGreaterThanOrEqual(1);
+      expect(v).toBeLessThanOrEqual(6);
+    });
+  });
+
+  it('rollAllDice returns six dice', () => {
+    const result = service.rollAllDice();
+    expect(result.length).toBe(6);
+  });
+
+  it('getReadyDice returns six zeros', () => {
+    expect(service.getReadyDice()).toEqual([0, 0, 0, 0, 0, 0]);
+  });
 });

--- a/src/app/services/scoring.spec.ts
+++ b/src/app/services/scoring.spec.ts
@@ -13,4 +13,34 @@ describe('Scoring', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  describe('getScoringOptions', () => {
+    it('detects a 1-6 straight', () => {
+      const dice = [1, 2, 3, 4, 5, 6];
+      const options = service.getScoringOptions(dice);
+      expect(options).toEqual([
+        { label: '1-6 Straight', score: 5000, dice: dice }
+      ]);
+    });
+
+    it('detects 3 pairs', () => {
+      const dice = [1, 1, 2, 2, 3, 3];
+      const options = service.getScoringOptions(dice);
+      expect(options).toEqual([
+        { label: '3 Pairs', score: 1250, dice: dice }
+      ]);
+    });
+
+    it('detects triples and singles', () => {
+      const dice = [1, 1, 1, 5];
+      const options = service.getScoringOptions(dice);
+      expect(options).toContainEqual({ label: "3 x 1's", score: 1000, dice: [1, 1, 1] });
+      expect(options).toContainEqual({ label: '5', score: 50, dice: [5] });
+    });
+
+    it('returns empty array when no score possible', () => {
+      const options = service.getScoringOptions([2, 3, 4]);
+      expect(options).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- expand dice and scoring service specs
- add spec for `NewGameModalComponent`

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_687276f30644832697221ee76925c004